### PR TITLE
Fix: Reliability

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,9 +22,6 @@ workflow:
     - if: $CI_PIPELINE_SOURCE == "web"
 
 .docker:
-  tags:
-    - docker
-    - linux
   image: docker:stable
   services:
     - docker:dind
@@ -52,9 +49,6 @@ workflow:
 
 .build:
   stage: build
-  tags:
-    - docker
-    - linux
   needs: []
   script:
     - autoreconf -i
@@ -65,9 +59,6 @@ workflow:
 
 .test:
   stage: test
-  tags:
-    - docker
-    - linux
   script:
     - touch aclocal.m4 configure config.status Makefile.in
     - make -t
@@ -299,9 +290,6 @@ docker:doc:
 
 doc:
   stage: build
-  tags:
-    - docker
-    - linux
   image: $REGISTRY/doc:bullseye
   needs: []
   script:
@@ -321,9 +309,6 @@ docker:cpplint:
 
 cpplint:
   stage: test
-  tags:
-    - docker
-    - linux
   image: $REGISTRY/cpplint:bullseye
   needs: []
   script:
@@ -343,9 +328,6 @@ docker:clang-format:
 
 clang-format:
   stage: test
-  tags:
-    - docker
-    - linux
   image: $REGISTRY/clang-format:bullseye
   needs: []
   script:
@@ -375,9 +357,6 @@ docker:valgrind:
 
 valgrind:
   stage: test
-  tags:
-    - docker
-    - linux
   image: $REGISTRY/valgrind:bullseye
   needs: []
   script:
@@ -401,9 +380,6 @@ valgrind:
 
 valgrind:ecss:
   stage: test
-  tags:
-    - docker
-    - linux
   image: $REGISTRY/valgrind:bullseye
   needs: []
   script:
@@ -427,9 +403,6 @@ docker:lcov:
 
 lcov:
   stage: test
-  tags:
-    - docker
-    - linux
   image: $REGISTRY/lcov:bullseye
   needs: []
   variables:
@@ -457,9 +430,6 @@ docker:scan-build:
 
 scan-build:
   stage: test
-  tags:
-    - docker
-    - linux
   image: $REGISTRY/scan-build:bullseye
   needs: []
   script:
@@ -481,9 +451,6 @@ docker:cppcheck-unix64:
 
 cppcheck-unix64:
   stage: test
-  tags:
-    - docker
-    - linux
   image: $REGISTRY/cppcheck-unix64:bullseye
   needs: []
   script:
@@ -518,9 +485,6 @@ docker:cppcheck-win64:
 
 cppcheck-win64:
   stage: test
-  tags:
-    - docker
-    - linux
   image: $REGISTRY/cppcheck-win64:bullseye
   needs: []
   script:
@@ -556,9 +520,6 @@ docker:python-checks:
 
 python-checks:
   stage: test
-  tags:
-    - docker
-    - linux
   image: $REGISTRY/python-checks:3.8-slim
   needs: []
   script:
@@ -577,9 +538,6 @@ docker:coverity:
 
 coverity:
   stage: test
-  tags:
-    - docker
-    - linux
   image: $REGISTRY/coverity:gcc9
   needs: []
   script:
@@ -613,9 +571,6 @@ docker:sonarcloud:
 
 sonarcloud:
   stage: test
-  tags:
-    - docker
-    - linux
   image: $REGISTRY/sonarcloud:bullseye
   needs: []
   variables:
@@ -647,9 +602,6 @@ sonarcloud:
 
 pages:
   stage: deploy
-  tags:
-    - docker
-    - linux
   image: alpine:latest
   needs: ["doc", "lcov"]
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -599,6 +599,7 @@ sonarcloud:
     - if: '$CI_MERGE_REQUEST_EVENT_TYPE != "merge_train"'
       when: always
     - when: never
+  allow_failure: true
 
 pages:
   stage: deploy

--- a/docker/gcc/Dockerfile
+++ b/docker/gcc/Dockerfile
@@ -2,6 +2,15 @@ ARG __GNUC__
 
 FROM gcc:${__GNUC__}
 
+# support for Debian 8 (GCC <= 6)
+RUN VERSION=$(sed 's/\..*//' /etc/debian_version) \
+    && if [ "$VERSION" -eq "8" ] ; then \
+          echo "deb [trusted=yes] http://archive.debian.org/debian/ jessie main non-free contrib" > /etc/apt/sources.list ; \
+    echo " deb-src [trusted=yes] http://archive.debian.org/debian/ jessie main non-free contrib" >> /etc/apt/sources.list ; \
+    echo "deb [trusted=yes] http://archive.debian.org/debian-security/ jessie/updates main non-free contrib" >> /etc/apt/sources.list ; \
+    echo " deb-src [trusted=yes] http://archive.debian.org/debian-security/ jessie/updates main non-free contrib" >> /etc/apt/sources.list ; \
+       fi
+
 RUN apt-get update -q \
     && DEBIAN_FRONTEND=noninteractive apt-get install -qy --no-install-recommends \
         cython3 \

--- a/include/lely/co/emcy.h
+++ b/include/lely/co/emcy.h
@@ -2,7 +2,7 @@
  * This header file is part of the CANopen library; it contains the emergency
  * (EMCY) object declarations.
  *
- * @copyright 2020 Lely Industries N.V.
+ * @copyright 2017-2024 Lely Industries N.V.
  *
  * @author J. S. Seldenthuis <jseldenthuis@lely.com>
  *
@@ -158,6 +158,35 @@ int co_emcy_pop(co_emcy_t *emcy, co_unsigned16_t *peec, co_unsigned8_t *per);
  */
 void co_emcy_peek(const co_emcy_t *emcy, co_unsigned16_t *peec,
 		co_unsigned8_t *per);
+
+/**
+ * Pops a CANopen EMCY message from the stack, even if it is not the most
+ * recent message, and broadcasts an 'error reset' message if the EMCY producer
+ * service is active.
+ *
+ * @param emcy a pointer to an EMCY producer service.
+ * @param n    the index of the message to be popped, where 0 is the most recent
+ *             message.
+ *
+ * @returns 0 on success, or -1 on error. In the latter case, the error number
+ * can be obtained with get_errc().
+ *
+ * @see co_emcy_find()
+ */
+int co_emcy_remove(co_emcy_t *emcy, size_t n);
+
+/**
+ * Finds a CANopen EMCY message in the stack. This function returns the index of
+ * the first matching message in LIFO order.
+ *
+ * @param emcy a pointer to an EMCY consumer service.
+ * @param eec  the emergency error code of the message to be found.
+ *
+ * @returns the index of the first matching message, or -1 if not found.
+ *
+ * @see co_emcy_remove()
+ */
+ssize_t co_emcy_find(const co_emcy_t *emcy, co_unsigned16_t eec);
 
 /**
  * Clears the CANopen EMCY message stack and broadcasts the 'error reset/no

--- a/include/lely/co/emcy.hpp
+++ b/include/lely/co/emcy.hpp
@@ -3,7 +3,7 @@
  * interface of the emergency (EMCY) object. See lely/co/emcy.h for the C
  * interface.
  *
- * @copyright 2017-2020 Lely Industries N.V.
+ * @copyright 2017-2024 Lely Industries N.V.
  *
  * @author J. S. Seldenthuis <jseldenthuis@lely.com>
  *
@@ -103,6 +103,16 @@ class COEmcy : public incomplete_c_type<__co_emcy> {
   void
   peek(co_unsigned16_t* peec = 0, co_unsigned8_t* per = 0) const noexcept {
     co_emcy_peek(this, peec, per);
+  }
+
+  int
+  remove(size_t n) noexcept {
+    return co_emcy_remove(this, n);
+  }
+
+  ssize_t
+  find(co_unsigned16_t eec) const noexcept {
+    return co_emcy_find(this, eec);
   }
 
   int

--- a/include/lely/coapp/master.hpp
+++ b/include/lely/coapp/master.hpp
@@ -1015,7 +1015,15 @@ class BasicMaster : public Node, protected ::std::map<uint8_t, DriverBase*> {
     ec.clear();
     auto sdo = GetSdo(id);
     if (sdo) {
-      SetTime();
+      try
+      {
+        SetTime();
+      }
+      catch (...)
+      {
+        ec = SdoErrc::ERROR;
+        return;
+      }
       sdo->SubmitUpload<T>(exec, idx, subidx, ::std::forward<F>(con), block,
                            timeout);
     } else {

--- a/src/co/emcy.c
+++ b/src/co/emcy.c
@@ -529,27 +529,7 @@ co_emcy_pop(co_emcy_t *emcy, co_unsigned16_t *peec, co_unsigned8_t *per)
 
 	co_emcy_peek(emcy, peec, per);
 
-	if (!emcy->nmsg)
-		return 0;
-
-	// Move the older messages.
-	if (--emcy->nmsg)
-		memmove(emcy->msgs, emcy->msgs + 1,
-				emcy->nmsg * sizeof(struct co_emcy_msg));
-
-	// Update the pre-defined error field.
-	if (emcy->obj_1003)
-		co_emcy_set_1003(emcy);
-
-	if (emcy->nmsg) {
-		// Store the next error in the error register and the
-		// manufacturer-specific field.
-		co_unsigned8_t msef[5] = { 0 };
-		stle_u16(msef, emcy->msgs[0].eec);
-		return co_emcy_send(emcy, 0, emcy->msgs[0].er, msef);
-	} else {
-		return co_emcy_send(emcy, 0, 0, NULL);
-	}
+	return co_emcy_remove(emcy, 0);
 }
 
 void
@@ -566,6 +546,49 @@ co_emcy_peek(const co_emcy_t *emcy, co_unsigned16_t *peec, co_unsigned8_t *per)
 			er |= emcy->msgs[i].er;
 		*per = er;
 	}
+}
+int
+co_emcy_remove(co_emcy_t *emcy, size_t n)
+{
+	assert(emcy);
+
+	if (n >= emcy->nmsg)
+		return 0;
+
+	// Move the older messages.
+	if (--emcy->nmsg)
+		memmove(emcy->msgs + n, emcy->msgs + n + 1,
+				(emcy->nmsg - n) * sizeof(struct co_emcy_msg));
+
+	// Update the pre-defined error field.
+	if (emcy->obj_1003)
+		co_emcy_set_1003(emcy);
+
+	if (emcy->nmsg) {
+		// Store the most recent error in the error register and the
+		// manufacturer-specific field.
+		co_unsigned16_t eec = 0;
+		co_unsigned8_t er = 0;
+		co_emcy_peek(emcy, &eec, &er);
+		co_unsigned8_t msef[5] = { 0 };
+		stle_u16(msef, eec);
+		return co_emcy_send(emcy, 0, er, msef);
+	} else {
+		return co_emcy_send(emcy, 0, 0, NULL);
+	}
+}
+
+ssize_t
+co_emcy_find(const co_emcy_t *emcy, co_unsigned16_t eec)
+{
+	assert(emcy);
+
+	for (size_t i = 0; i < emcy->nmsg; i++) {
+		if (emcy->msgs[i].eec == eec)
+			return i;
+	}
+
+	return -1;
 }
 
 int

--- a/src/co/sync.c
+++ b/src/co/sync.c
@@ -4,7 +4,7 @@
  *
  * @see lely/co/sync.h
  *
- * @copyright 2017-2022 Lely Industries N.V.
+ * @copyright 2017-2024 Lely Industries N.V.
  *
  * @author J. S. Seldenthuis <jseldenthuis@lely.com>
  *
@@ -288,6 +288,9 @@ co_sync_stop(co_sync_t *sync)
 
 	if (sync->stopped)
 		return;
+
+	can_timer_stop(sync->timer);
+	can_recv_stop(sync->recv);
 
 	// Remove the download indication function for the synchronous counter
 	// overflow value object.

--- a/src/co/time.c
+++ b/src/co/time.c
@@ -4,7 +4,7 @@
  *
  * @see lely/co/time.h
  *
- * @copyright 2016-2022 Lely Industries N.V.
+ * @copyright 2016-2023 Lely Industries N.V.
  *
  * @author J. S. Seldenthuis <jseldenthuis@lely.com>
  *
@@ -100,7 +100,7 @@ co_time_of_day_get(const co_time_of_day_t *tod, struct timespec *tp)
 	// Convert the CANopen time (seconds since January 1, 1984) to the Unix
 	// epoch (seconds since January 1, 1970). This is a difference of 14
 	// years and 3 leap days.
-	co_time_diff_t td = { .ms = tod->ms, .days = tod->days };
+	const co_time_diff_t td = { .ms = tod->ms, .days = tod->days };
 	co_time_diff_get(&td, tp);
 	tp->tv_sec += (14 * 365 + 3) * 24 * 60 * 60;
 }
@@ -114,12 +114,14 @@ co_time_of_day_set(co_time_of_day_t *tod, const struct timespec *tp)
 	// Convert the Unix epoch (seconds since January 1, 1970) to the CANopen
 	// time (seconds since January 1, 1984). This is a difference of 14
 	// years and 3 leap days.
-	co_time_diff_t td = { .ms = tod->ms, .days = tod->days };
+	co_time_diff_t td = { 0, 0 };
 	// clang-format off
 	co_time_diff_set(&td, &(struct timespec){
 			tp->tv_sec - (14 * 365 + 3) * 24 * 60 * 60,
 			tp->tv_nsec });
 	// clang-format on
+	tod->ms = td.ms;
+	tod->days = td.days;
 }
 
 void

--- a/src/util/mkjmp.c
+++ b/src/util/mkjmp.c
@@ -4,7 +4,7 @@
  *
  * @see lely/util/mkjmp.h
  *
- * @copyright 2018-2019 Lely Industries N.V.
+ * @copyright 2018-2024 Lely Industries N.V.
  *
  * @author J. S. Seldenthuis <jseldenthuis@lely.com>
  *
@@ -187,7 +187,8 @@ sigctx_func(void)
 	void (*func)(void *) = sigctx.func;
 	void *arg = sigctx.arg;
 
-	// Save the current environment, on succes, and jump back to sigmkjmp().
+	// Save the current environment, on success, and jump back to
+	// sigmkjmp().
 	if (!sigsetjmp(sigctx.penv, sigctx.savemask))
 		siglongjmp(sigctx.env, 1);
 


### PR DESCRIPTION
Catch set time to prevent node from exiting when interface is unavailable. 

And, update master branch with changes used on `ros2_canopen`